### PR TITLE
Update bans.kv

### DIFF
--- a/src/scripts/kv/bans.kv
+++ b/src/scripts/kv/bans.kv
@@ -274,6 +274,7 @@
         "item_ward_observer"            "1"
         "item_ward_sentry"              "1"
         "item_bottle"                   "1"
+        "bristleback_quill_spray"           "1"
     }
 
     // Abiltiies that won't have their cooldowns lowered by our patch

--- a/src/scripts/kv/bans.kv
+++ b/src/scripts/kv/bans.kv
@@ -23,7 +23,13 @@
             "viper_poison_attack"                   "1"
             "warlock_golem_permanent_immolation"    "1"
         }
-
+        
+        // Quill Spray abuse
+        "bristleback_quill_spray" {
+            "ogre_magi_multicast_lod"       "1"
+            "death_prophet_witchcraft"      "1"
+        }
+        
         // Multishot abuse
         "holdout_multishot" {
             "ember_spirit_sleight_of_fist"  "1"
@@ -274,7 +280,6 @@
         "item_ward_observer"            "1"
         "item_ward_sentry"              "1"
         "item_bottle"                   "1"
-        "bristleback_quill_spray"           "1"
     }
 
     // Abiltiies that won't have their cooldowns lowered by our patch


### PR DESCRIPTION
Added ban to Quill Spray in the multicast category. It is seen in almost 100% of pub LoD games with the Quill Spray, Witchcraft, Perm Invis, Multicast combo. It is essentially instakill on any hero.