### PR TITLE
Couriers now spawn at start from players inventroy.

### DIFF
--- a/src/scripts/vscripts/pregame.lua
+++ b/src/scripts/vscripts/pregame.lua
@@ -4470,15 +4470,19 @@ function Pregame:fixSpawningIssues()
                     })
                 end
 
-                if OptionManager:GetOption('freeCourier') then
+               if OptionManager:GetOption('freeCourier') then
                     local team = spawnedUnit:GetTeam()
-
+					
                     if not givenCouriers[team] then
-                    	givenCouriers[team] = true
-                    	spawnedUnit:AddItemByName('item_courier')
-
-                    	-- TODO: Auto activate
-                    	-- item_flying_courier
+                    	givenCouriers[team] = true		
+						
+			--Timer is necessary to prevent bug with courier spawning in center of map (Probably because it takes players a moment to be allocated to their team). "item_courier_start" is a modified courier that spawns on pickup.
+						
+			Timers:CreateTimer(function()
+				spawnedUnit:AddItemByName('item_courier_start')
+				end, DoUniqueString('spawncourier'), 1)
+                    	
+						
                     end
                 end
 

--- a/src/scripts/vscripts/pregame.lua
+++ b/src/scripts/vscripts/pregame.lua
@@ -4479,8 +4479,11 @@ function Pregame:fixSpawningIssues()
 			--Timer is necessary to prevent bug with courier spawning in center of map (Probably because it takes players a moment to be allocated to their team). "item_courier_start" is a modified courier that spawns on pickup.
 						
 			Timers:CreateTimer(function()
-				spawnedUnit:AddItemByName('item_courier_start')
-				end, DoUniqueString('spawncourier'), 1)
+				if IsValidEntity(spawnedUnit) then
+				 	spawnedUnit:AddItemByName('item_courier_start')
+				end
+				
+			end, DoUniqueString('spawncourier'), 1)
                     	
 						
                     end


### PR DESCRIPTION
Couriers will no longer stay in the player's inventory at game-start. It will spawn after a 1 second delay (to prevent bugs). "item_courier_start" is copy of normal courier only it gets cast on pickup and can't be purchased. **Requires approving commit to npc_custom_items to work.**