### PR TITLE
Update addon_english.txt - Fixed modifier description for Aghanim Scepter Buff

### DIFF
--- a/script_generator/CUSTOM/addon_english.txt
+++ b/script_generator/CUSTOM/addon_english.txt
@@ -507,7 +507,9 @@
 		"DOTA_Tooltip_ability_item_force_boots_bonus_movement_speed"	"+$move_speed"
 		"DOTA_Tooltip_ability_item_force_boots_bonus_str"				"+$all"
 		"DOTA_Tooltip_ability_item_force_boots_bonus_attack_speed"		"+$attack"
-
+		
+		"DOTA_Tooltip_modifier_item_ultimate_scepter_consumed" "Aghanim's Scepter BUFF"
+		"DOTA_Tooltip_modifier_item_ultimate_scepter_consumed_Description" "Permanently granted 'Ultimate Upgrade' benefit from Aghanim's Scepter. Certain ultimates and abilities will be upgraded."
 
 		/////////////////
 		// CUSTOM ABILITIES


### PR DESCRIPTION
By overriding the default description and name for the scepter_consumed buff, the now buff reads more accurately. It no longer says anything about stats being increased. 
![image](https://cloud.githubusercontent.com/assets/16277198/15055660/0e0ee156-1351-11e6-87aa-4074c6fb780d.png)

