### PR TITLE
Added Two Hints - Add Icons to Old Ones

### DIFF
--- a/src/localization/addon_english.txt
+++ b/src/localization/addon_english.txt
@@ -277,7 +277,7 @@
     "hintEmpoweringHaste"                           "Empowering Haste and Thirst make for a lethal combination!"
     "hintInfestHacks"                               "Many spells such as Pudge's Rot and Witch Doctor's Voodoo Restoration won't damage you, or cost mana when you infest another hero."
     "hintSuggestBuild"                              "Do you know a good build? Submit it and it may be added to the recommended builds sections."
-    "hintBreakPassives"                             "Silver Edge, Doom and Demonic Purge are the only 3 ways to disable enemy passives, which can be very useful against passive-heavy heroes, such as Tanks."
+    "hintBreakPassives"                             "Silver Edge, Doom and Demonic Purge are the only ways to disable enemy passives, which can be very useful against passive-heavy heroes, such as Tanks."
     "hintInnateAbilities"                           "Night Stalker, Gyrocopter and Elazor will benefit from Aghanim's Scepter Upgrade, irrespective of their chosen abilities."
     
     // Hero builder

--- a/src/localization/addon_english.txt
+++ b/src/localization/addon_english.txt
@@ -277,7 +277,7 @@
     "hintEmpoweringHaste"                           "Empowering Haste and Thirst make for a lethal combination!"
     "hintInfestHacks"                               "Many spells such as Pudge's Rot and Witch Doctor's Voodoo Restoration won't damage you, or cost mana when you infest another hero."
     "hintSuggestBuild"                              "Do you know a good build? Submit it and it may be added to the recommended builds sections."
-    "hintBreakPassives"                             "Silver Edge, Doom and Demonic Purge are the only ways to disable enemy passives, which can be very useful against passive-heavy heroes, such as Tanks."
+    "hintBreakPassives"                             "Silver Edge, Doom and Demonic Purge are the only ways to disable enemy passives - which can be very useful against passive-heavy heroes, such as Tanks."
     "hintInnateAbilities"                           "Night Stalker, Gyrocopter and Elazor will benefit from Aghanim's Scepter Upgrade, irrespective of their chosen abilities."
     
     // Hero builder

--- a/src/localization/addon_english.txt
+++ b/src/localization/addon_english.txt
@@ -278,6 +278,7 @@
     "hintInfestHacks"                               "Many spells such as Pudge's Rot and Witch Doctor's Voodoo Restoration won't damage you, or cost mana when you infest another hero."
     "hintSuggestBuild"                              "Do you know a good build? Submit it and it may be added to the recommended builds sections."
     "hintBreakPassives"                             "Silver Edge, Doom and Demonic Purge are the only 3 ways to disable enemy passives, which can be very useful against passive-heavy heroes, such as Tanks."
+    "hintInnateAbilities"                           "Night Stalker, Gyrocopter and Elazor will benefit from Aghanim's Scepter Upgrade, irrespective of their chosen abilities."
     
     // Hero builder
     "finishBanning"                                 "Finish Banning"

--- a/src/localization/addon_english.txt
+++ b/src/localization/addon_english.txt
@@ -277,7 +277,8 @@
     "hintEmpoweringHaste"                           "Empowering Haste and Thirst make for a lethal combination!"
     "hintInfestHacks"                               "Many spells such as Pudge's Rot and Witch Doctor's Voodoo Restoration won't damage you, or cost mana when you infest another hero."
     "hintSuggestBuild"                              "Do you know a good build? Submit it and it may be added to the recommended builds sections."
-
+    "hintBreakPassives"                             "Silver Edge, Doom and Demonic Purge are the only 3 ways to disable enemy passives, which can very useful against passive-heavy heroes, such as Tanks."
+    
     // Hero builder
     "finishBanning"                                 "Finish Banning"
     "unlockBuild"                                   "Unlock Build"

--- a/src/localization/addon_english.txt
+++ b/src/localization/addon_english.txt
@@ -277,7 +277,7 @@
     "hintEmpoweringHaste"                           "Empowering Haste and Thirst make for a lethal combination!"
     "hintInfestHacks"                               "Many spells such as Pudge's Rot and Witch Doctor's Voodoo Restoration won't damage you, or cost mana when you infest another hero."
     "hintSuggestBuild"                              "Do you know a good build? Submit it and it may be added to the recommended builds sections."
-    "hintBreakPassives"                             "Silver Edge, Doom and Demonic Purge are the only 3 ways to disable enemy passives, which can very useful against passive-heavy heroes, such as Tanks."
+    "hintBreakPassives"                             "Silver Edge, Doom and Demonic Purge are the only 3 ways to disable enemy passives, which can be very useful against passive-heavy heroes, such as Tanks."
     
     // Hero builder
     "finishBanning"                                 "Finish Banning"

--- a/src/panorama/scripts/custom_game/loading_screen.js
+++ b/src/panorama/scripts/custom_game/loading_screen.js
@@ -77,6 +77,9 @@ function onGetPlayerStats(table_name, key, data) {
     }, {
         img: 'file://{images}/items/silver_edge.png',
         txt: '#hintBreakPassives'
+    }, {
+        img: 'file://{images}/spellicons/night_stalker_darkness.png',
+        txt: '#hintInnateAbilities'
     }];
 
     // How long to wait before we show the next tip

--- a/src/panorama/scripts/custom_game/loading_screen.js
+++ b/src/panorama/scripts/custom_game/loading_screen.js
@@ -74,6 +74,9 @@ function onGetPlayerStats(table_name, key, data) {
     }, {
         img: 'file://{images}/spellicons/invoker_empty1.png',
         txt: '#hintSuggestBuild'
+    }, {
+        img: 'file://{images}/items/silver_edge.png',
+        txt: '#hintBreakPassives'
     }];
 
     // How long to wait before we show the next tip

--- a/src/panorama/scripts/custom_game/loading_screen.js
+++ b/src/panorama/scripts/custom_game/loading_screen.js
@@ -66,13 +66,13 @@ function onGetPlayerStats(table_name, key, data) {
         img: 'file://{images}/spellicons/witch_doctor_voodoo_restoration.png',
         txt: '#hintInfestHacks'
     }, {
-        img: 'file://{images}/spellicons/invoker_empty1.png',
+        img: 'file://{images}/items/gem.png',
         txt: '#hintSuggestHint'
     }, {
         img: 'file://{images}/custom_game/hints/hint_empowering_haste.png',
         txt: '#hintEmpoweringHaste'
     }, {
-        img: 'file://{images}/spellicons/invoker_empty1.png',
+        img: 'file://{images}/items/recipe.png',
         txt: '#hintSuggestBuild'
     }, {
         img: 'file://{images}/items/silver_edge.png',


### PR DESCRIPTION
Considering how dominant and common tank builds are, I think it is a good idea to inform players that there is method of breaking passives. 
![image](https://cloud.githubusercontent.com/assets/16277198/15163411/b036722a-174b-11e6-9685-00d2d324521f.png)

![hint2](https://cloud.githubusercontent.com/assets/16277198/15167707/8248e906-176e-11e6-8ad4-2151ac4c9ad0.png)

New Icons

![image](https://cloud.githubusercontent.com/assets/16277198/15169193/0eb3bb52-177c-11e6-95af-adcb1ee32271.png)

![image](https://cloud.githubusercontent.com/assets/16277198/15169199/1c823830-177c-11e6-974f-ce98abb68105.png)


