### PR TITLE
Removed elder_titan_return_spirit from pool of selectable abilities

### DIFF
--- a/src/panorama/scripts/custom_game/game_setup.js
+++ b/src/panorama/scripts/custom_game/game_setup.js
@@ -1138,6 +1138,26 @@ function hookTabChange(tabName, callback) {
     onLoadTabHook[tabName] = callback;
 }
 
+// Makes hero info appear when you hover the panel that is parsed in
+function hookHeroInfo(panel) {
+    // Show
+    panel.SetPanelEvent('onmouseover', function() {
+        var heroName = panel.GetAttributeString('heroName', '');
+        var info = heroData[heroName];
+
+        var displayNameTitle = $.Localize(heroName);
+        var heroStats = GenerateFormattedHeroStatsString(heroName, info);
+
+        $.DispatchEvent('DOTAShowTitleTextTooltipStyled', panel, displayNameTitle, heroStats, "testStyle");
+        //$.DispatchEvent('DOTAShowHeroStatsTooltip', string heroName, uint8 styleIndex, int32 heroID);
+    });
+
+    // Hide
+    panel.SetPanelEvent('onmouseout', function() {
+        $.DispatchEvent('DOTAHideTitleTextTooltip');
+    });
+}
+
 // Makes skill info appear when you hover the panel that is parsed in
 function hookSkillInfo(panel) {
     // Show
@@ -1751,6 +1771,7 @@ function buildHeroList() {
 
                 // Create the panel
                 var newPanel = $.CreatePanel('DOTAHeroImage', container, 'heroSelector_' + heroName);
+                hookHeroInfo(newPanel);
                 newPanel.SetAttributeString('heroName', heroName);
                 newPanel.heroname = heroName;
                 newPanel.heroimagestyle = 'portrait';
@@ -2127,6 +2148,7 @@ function toggleShowDraftSkills() {
 
 // Makes the given hero container selectable
 function makeHeroSelectable(heroCon) {
+
     heroCon.SetPanelEvent('onactivate', function() {
         var heroName = heroCon.GetAttributeString('heroName', '');
         if(heroName == null || heroName.length <= 0) return;
@@ -2150,7 +2172,7 @@ function makeHeroSelectable(heroCon) {
         displayPanel.SetAttributeString('heroName', heroName);
 
         // Hide skill info
-        $.DispatchEvent('DOTAHideAbilityTooltip');
+        $.DispatchEvent('DOTAHideTitleTextTooltip');
 
         // Highlight drop cell
         $('#pickingPhaseSelectedHeroImage').SetHasClass('lodSelectedDrop', true)
@@ -3627,6 +3649,44 @@ function OnTeamPlayerListChanged() {
             OnTeamPlayerListChanged();
         }
     });
+}
+
+//--------------------------------------------------------------------------------------------------
+//Generate formatted string of Hero stats from sent
+//--------------------------------------------------------------------------------------------------
+function GenerateFormattedHeroStatsString( heroName, info ) {
+
+    var heroStats = '';
+    heroStats += '<font color=\'#7C7C7C\'>_____________________________________</font><br>';
+    heroStats += '<font color=\'#FFFFFF\'>' + $.Localize('heroStats_Damage') + ':</font> <font color=\'#7C7C7C\'>' + info.AttackDamageMin + '-' + info.AttackDamageMax + '</font><br>';
+    heroStats += '<font color=\'#FFFFFF\'>' + $.Localize('heroStats_Armor') + ':</font> <font color=\'#7C7C7C\'>' + '</font><br>';
+    heroStats += '<font color=\'#FFFFFF\'>' + $.Localize('heroStats_attackPoints') + ':</font> <font color=\'#7C7C7C\'>' + '</font><br>';
+    heroStats += '<font color=\'#FFFFFF\'>' + $.Localize('heroStats_baseAttackTime') + ':</font> <font color=\'#7C7C7C\'>' + parseFloat(Math.round(info.AttackRate * 10) / 10).toFixed(1) + '</font><br>';
+    heroStats += '<font color=\'#00FF83\'>' + $.Localize('heroStats_baseHPRegen') + ': ' + '</font><br>';
+    heroStats += '<font color=\'#7C7C7C\'>_____________________________________</font><br>';
+
+    heroStats += ((info.AttributePrimary == 'DOTA_ATTRIBUTE_STRENGTH') ? '<font color=\'#FF0000\'>' : '<font color=\'#B6E002\'>') + $.Localize('heroStats_strength') + ':</font> <font color=\'#7C7C7C\'>' + info.AttributeBaseStrength + ' + ' + parseFloat(Math.round(info.AttributeStrengthGain * 10) / 10).toFixed(1) + '</font><br>';
+    heroStats += ((info.AttributePrimary == 'DOTA_ATTRIBUTE_AGILITY') ? '<font color=\'#FF0000\'>' : '<font color=\'#B6E002\'>') + $.Localize('heroStats_agility') + ':</font> <font color=\'#7C7C7C\'>' + info.AttributeBaseAgility + ' + ' + parseFloat(Math.round(info.AttributeAgilityGain * 10) / 10).toFixed(1) + '</font><br>';
+    heroStats += ((info.AttributePrimary == 'DOTA_ATTRIBUTE_INTELLECT') ? '<font color=\'#FF0000\'>' : '<font color=\'#B6E002\'>') + $.Localize('heroStats_intelligence') + ':</font> <font color=\'#7C7C7C\'>' + info.AttributeBaseIntelligence + ' + ' + parseFloat(Math.round(info.AttributeIntelligenceGain * 10) / 10).toFixed(1) + '</font><br>';
+    heroStats += '<br>';
+
+    var startingAttributes = info.AttributeBaseStrength + info.AttributeBaseAgility + info.AttributeBaseIntelligence;
+    var attributesPerLevel = info.AttributeStrengthGain + info.AttributeAgilityGain + info.AttributeIntelligenceGain;
+    attributesPerLevel = parseFloat(Math.round(attributesPerLevel * 10) / 10).toFixed(1);
+
+    heroStats += '<font color=\'#CF6700\'>' + $.Localize('heroStats_attributes_starting') + ':</font> <font color=\'#7C7C7C\'>' + startingAttributes + '</font><br>';
+    heroStats += '<font color=\'#CF6700\'>' + $.Localize('heroStats_attributes_perLevel') + ':</font> <font color=\'#7C7C7C\'>' + attributesPerLevel + '</font><br>';
+    heroStats += '<font color=\'#7C7C7C\'>____________________________________</font><br>';
+    heroStats += '<font color=\'#FFFFFF\'>' + $.Localize('heroStats_attackRange') + ':</font> <font color=\'#7C7C7C\'>' + info.AttackRange + '</font><br>';
+    heroStats += '<font color=\'#FFFFFF\'>' + $.Localize('heroStats_movementSpeed') + ':</font> <font color=\'#7C7C7C\'>' + info.MovementSpeed + '</font><br>';
+
+    //MISSING / ?? heroStats += 'UNIQUE MECHANIC: ';
+    if($.Localize("unique_mechanic_" + heroName.substring(14)) != "unique_mechanic_" + heroName.substring(14)){
+        var warning = $.Localize('warning_' + heroName.substring(14));
+        heroStats += '<br><font color=\'#23FF27\'>' + $.Localize('heroStats_uniqueMechanic') + ':</font> <font color=\'#7C7C7C\'>' + $.Localize('unique_mechanic_' + heroName.substring(14)) + '</font><br>';
+    }
+
+    return heroStats;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/scripts/kv/abilities.kv
+++ b/src/scripts/kv/abilities.kv
@@ -119,7 +119,7 @@
                   "elder_titan_earth_splitter"    "114"
                   "elder_titan_echo_stomp"    "115"
                   "elder_titan_natural_order" "116"
-                  // "elder_titan_return_spirit" "117"
+                  "elder_titan_return_spirit" "117"
                   "ember_spirit_activate_fire_remnant"    "118"
                   "ember_spirit_fire_remnant" "119"
                   "ember_spirit_flame_guard"  "120"

--- a/src/scripts/kv/abilities.kv
+++ b/src/scripts/kv/abilities.kv
@@ -119,7 +119,7 @@
                   "elder_titan_earth_splitter"    "114"
                   "elder_titan_echo_stomp"    "115"
                   "elder_titan_natural_order" "116"
-                  "elder_titan_return_spirit" "117"
+                  // "elder_titan_return_spirit" "117"
                   "ember_spirit_activate_fire_remnant"    "118"
                   "ember_spirit_fire_remnant" "119"
                   "ember_spirit_flame_guard"  "120"


### PR DESCRIPTION
#257

"I don't see the point of Astral Spirit Return. You can't skill it without at least one point in Astral spirit. It has no effect by itself. It deletes itself after you cast astral spirit once. And you already get that ability when u cast astral spirit (the button switches). As far as I can tell it is a useless ability, and thus I suggest we remove it from the pool of abilities."